### PR TITLE
Add OSS post summary

### DIFF
--- a/_posts/2015-08-10-open-source-strategy.md
+++ b/_posts/2015-08-10-open-source-strategy.md
@@ -1,0 +1,16 @@
+---
+layout: post
+title:  An Open Source Strategy for ATS
+description: ATS released our first open source project in early 2013. This paper outlines some of the reasoning behind our OSS contributions.
+date:   2015-08-10 15:20:00
+author: Nathan Evans
+platform: Medium
+original: https://medium.com/@natoverse/an-open-source-strategy-for-ats-c5cca250ef48
+category: blog
+---
+
+The following is a position paper I put together for the ATS management team in late 2012. It was intended to introduce them to the idea of open source as something that we, as a for-profit company, could participate in.
+
+We’ve come a long way in our embrace of the open source ethos, and some of the statements here feel out-dated (for example, we’re much more *lassiez-faire* about what we release than I expected). I love how this has taken off within the company, and it makes me happy that we’ve run with the best parts of what’s here, and ignored the bad parts.
+
+In the interest of transparency, I’ve reproduced the paper nearly verbatim from the original, with only minor typo edits and removal of a couple of contract references.


### PR DESCRIPTION
I've publicly published the OSS paper from a couple of years ago, and want to get a link to it from the engineering site. This was previously only available on the internal R&D confluence site.