### PR TITLE
#22 - Fix salt bootstrap options

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,7 +29,7 @@ Vagrant.configure(2) do |config|
 
   # Provision with salt
   config.vm.provision :salt do |salt|
-    salt.bootstrap_options = "-P"
+    salt.bootstrap_options = "-F -c /tmp -P"
     salt.minion_config = "salt/minion"
     salt.run_highstate = true
     salt.verbose = true


### PR DESCRIPTION
I added command line params per the comments on the vagrant issue.

-F = force overwrite of existing config files (without this, `vagrant provision` would fail due to existing files)
-c /tmp = specifies config directory to use